### PR TITLE
Feat: Remove CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,9 +6,7 @@ before:
     - go generate ./...
     - make build-web
 builds:
-  - env:
-      - CGO_ENABLED=0
-    binary: forky-{{.Version}}
+  - binary: forky-{{.Version}}
     goos:
       - linux
       - windows


### PR DESCRIPTION
```
[error] failed to initialize database, got error Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
time="2023-03-29T04:16:21Z" level=fatal msg="failed to create indexer: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub"
```