### PR TITLE
feat(store): Add TTL Cache for frames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.3.0 // indirect
+	github.com/jellydator/ttlcache/v3 v3.0.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,8 @@ github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZ
 github.com/jackc/pgx/v5 v5.3.0 h1:/NQi8KHMpKWHInxXesC8yD4DhkXPrVhmnwYkjp9AmBA=
 github.com/jackc/pgx/v5 v5.3.0/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
 github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
+github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=

--- a/pkg/forky/store/metrics.go
+++ b/pkg/forky/store/metrics.go
@@ -10,6 +10,9 @@ type BasicMetrics struct {
 	itemsRemoved   *prometheus.CounterVec
 	itemsRetreived *prometheus.CounterVec
 	itemsStored    *prometheus.GaugeVec
+
+	cacheHit  *prometheus.CounterVec
+	cacheMiss *prometheus.CounterVec
 }
 
 func NewBasicMetrics(namespace, storeType string, enabled bool) *BasicMetrics {
@@ -42,6 +45,16 @@ func NewBasicMetrics(namespace, storeType string, enabled bool) *BasicMetrics {
 			Name:      "items_stored_total",
 			Help:      "Number of items stored in the store",
 		}, []string{"type"}),
+		cacheHit: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "cache_hit_count",
+			Help:      "Number of cache hits",
+		}, []string{"type"}),
+		cacheMiss: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "cache_miss_count",
+			Help:      "Number of cache misses",
+		}, []string{"type"}),
 	}
 
 	if enabled {
@@ -50,6 +63,8 @@ func NewBasicMetrics(namespace, storeType string, enabled bool) *BasicMetrics {
 		prometheus.MustRegister(m.itemsRemoved)
 		prometheus.MustRegister(m.itemsRetreived)
 		prometheus.MustRegister(m.itemsStored)
+		prometheus.MustRegister(m.cacheHit)
+		prometheus.MustRegister(m.cacheMiss)
 	}
 
 	m.info.WithLabelValues(storeType).Set(1)
@@ -71,4 +86,12 @@ func (m *BasicMetrics) ObserveItemRetreived(itemType string) {
 
 func (m *BasicMetrics) ObserveItemStored(itemType string, count int) {
 	m.itemsStored.WithLabelValues(itemType).Set(float64(count))
+}
+
+func (m *BasicMetrics) ObserveCacheHit(itemType string) {
+	m.cacheHit.WithLabelValues(itemType).Inc()
+}
+
+func (m *BasicMetrics) ObserveCacheMiss(itemType string) {
+	m.cacheMiss.WithLabelValues(itemType).Inc()
 }


### PR DESCRIPTION
Adds an in-memory cache for Frames. Since most of our traffic will be "recent" frames, this should greatly reduce our s3 data transfer costs.