### PR TITLE
fix(indexer): Gracefully handle already-deleted frames

### DIFF
--- a/pkg/forky/db/indexer.go
+++ b/pkg/forky/db/indexer.go
@@ -501,7 +501,7 @@ func (i *Indexer) DeleteFrameMetadata(ctx context.Context, id string) error {
 
 	query := i.db.WithContext(ctx)
 
-	result := query.Unscoped().Where("id = ?", id).Delete(&FrameMetadata{})
+	result := query.Where("id = ?", id).Delete(&FrameMetadata{})
 	if result.Error != nil {
 		i.metrics.ObserveOperationError(operation)
 
@@ -514,7 +514,7 @@ func (i *Indexer) DeleteFrameMetadata(ctx context.Context, id string) error {
 		return errors.New("frame_metadata not found")
 	}
 
-	result = query.Unscoped().Where("frame_id = ?", id).Delete(&FrameMetadataLabels{})
+	result = query.Where("frame_id = ?", id).Delete(&FrameMetadataLabels{})
 	if result.Error != nil {
 		i.metrics.ObserveOperationError(operation)
 

--- a/pkg/forky/service/service.go
+++ b/pkg/forky/service/service.go
@@ -389,7 +389,7 @@ func (f *ForkChoice) DeleteFrame(ctx context.Context, id string) error {
 		return ErrInvalidID
 	}
 
-	if err := f.store.DeleteFrame(ctx, id); err != nil {
+	if err := f.store.DeleteFrame(ctx, id); err != nil && err != store.ErrFrameNotFound {
 		f.metrics.ObserveOperationError(operation)
 
 		f.log.WithError(err).WithField("id", id).Error("failed to delete frame")


### PR DESCRIPTION
Fixes an issue where the store may have already deleted a frame (ie. with S3 lifecycle rules)