### PR TITLE
chore(web): web tweaks

### DIFF
--- a/web/src/components/SnapshotMarker.tsx
+++ b/web/src/components/SnapshotMarker.tsx
@@ -50,6 +50,7 @@ function SnapshotMarker({
             i === 0 && 'rounded-t-full',
             i === numberOfSegments - 1 && 'rounded-b-full',
           )}
+          title={`${metadata[i].node} - ${metadata[i].id}`}
         />,
       );
     }

--- a/web/src/hooks/useActive.ts
+++ b/web/src/hooks/useActive.ts
@@ -14,8 +14,16 @@ function findLatestFrameIdPerNode(
   metadata: FrameMetaData[] = [],
   focusedNode?: string,
 ): State {
-  // Filter metadata to include only frames with fetched_at before focusedTime
-  metadata = metadata.filter((frame) => new Date(frame.fetched_at).getTime() < focusedTime);
+  // Filter metadata
+  metadata = metadata.filter((frame) => {
+    // only frames with fetched_at before focusedTime
+    if (new Date(frame.fetched_at).getTime() >= focusedTime) return false;
+    // only frames that are not a reorg
+    if (frame.labels?.includes('xatu_event_name=BEACON_API_ETH_V1_DEBUG_FORK_CHOICE_REORG'))
+      return false;
+
+    return true;
+  });
 
   // Group metadata by node
   let groupedMetadata: { [key: string]: FrameMetaData[] } = {};

--- a/web/src/parts/Graph.tsx
+++ b/web/src/parts/Graph.tsx
@@ -259,7 +259,7 @@ function Graph({ data, ids, unique }: { data: ProcessedData[]; ids: string[]; un
     <>
       {location.startsWith('/node/') && (
         <button
-          className="absolute text-stone-900 dark:text-stone-100 mt-24 ml-5 lg:ml-8 z-20 flex items-center p-2 rounded transition hover:bg-stone-900/5 dark:hover:bg-white/5"
+          className="absolute text-stone-900 dark:text-stone-100 mt-24 ml-5 lg:ml-8 z-20 flex text-xs 2xl:text-sm items-center p-1 2xl:p-2 rounded transition hover:bg-stone-900/5 dark:hover:bg-white/5"
           onClick={handleNavigateAggregatedView}
         >
           <ArrowLeftCircleIcon className="h-6 w-6 mr-1" />
@@ -269,7 +269,7 @@ function Graph({ data, ids, unique }: { data: ProcessedData[]; ids: string[]; un
       {type === 'weighted' && (
         <button
           className={classNames(
-            'absolute text-stone-900 dark:text-stone-100 ml-5 lg:ml-8 z-20 flex items-center p-2 rounded transition hover:bg-stone-900/5 dark:hover:bg-white/5',
+            'absolute text-stone-900 dark:text-stone-100 ml-5 lg:ml-8 z-20 flex text-xs 2xl:text-sm items-center p-1 2xl:p-2 rounded transition hover:bg-stone-900/5 dark:hover:bg-white/5',
             location.startsWith('/node/') ? 'mt-36' : ' mt-24',
           )}
           onClick={() => {
@@ -344,7 +344,7 @@ function Graph({ data, ids, unique }: { data: ProcessedData[]; ids: string[]; un
               <span
                 onClick={handleFocus}
                 title="Focus to the head of the canonical chain"
-                className="fixed z-10 righttype-6 lg:right-8 top-36 text-stone-700 dark:text-stone-300 cursor-pointer w-10 h-10 rounded-md transition hover:bg-stone-900/5 dark:hover:bg-white/5"
+                className="fixed z-10 right-6 lg:right-8 top-36 text-stone-700 dark:text-stone-300 cursor-pointer w-10 h-10 rounded-md transition hover:bg-stone-900/5 dark:hover:bg-white/5"
               >
                 <span className="sr-only">Focus to the head of the canonical chain</span>
                 {focused && (

--- a/web/src/parts/Selection.tsx
+++ b/web/src/parts/Selection.tsx
@@ -1,8 +1,9 @@
-import { Fragment } from 'react';
+import { Fragment, useEffect } from 'react';
 
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
+import { useLocation } from 'wouter';
 
 import AggregatedBlockSummary from '@components/AggregatedBlockSummary';
 import AggregatedFramesSummary from '@components/AggregatedFramesSummary';
@@ -13,6 +14,9 @@ import useSelection from '@contexts/selection';
 export default function Selection() {
   const { frameId, aggregatedFrameIds, frameBlock, aggregatedFramesBlock, clearAll } =
     useSelection();
+  const [location] = useLocation();
+
+  useEffect(clearAll, [location]);
 
   return (
     <div className="bg-stone-900">


### PR DESCRIPTION
- filter out xatu reorg events from rendering in the graph (still shown on the timeline)
- hide slideout on navigation change
- fix focus icon on mobile
- add title on timeline market hover
- fix font size on mobile